### PR TITLE
Add libcurl build phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
           fi
 
       - name: Build toolchain
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./build.sh --ndk $ANDROID_NDK_LATEST_HOME --dist-root HOME/${{matrix.android-dir}}/GNUstep
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The toolchain is built using the Android NDK (installed e.g. via [Android Studio
 Libraries
 ---------
 
-The toolchain currently compiles the following libraries for Android:
+The toolchain consists of the following libraries:
 
 * [GNUstep Base Library](https://github.com/gnustep/libs-base) (Foundation)
 * [GNUstep CoreBase Library](https://github.com/gnustep/libs-corebase) (CoreFoundation)
@@ -21,6 +21,8 @@ The toolchain currently compiles the following libraries for Android:
 * [libiconv](https://www.gnu.org/software/libiconv/)
 * [libxml2](https://github.com/GNOME/libxml2)
 * [libxslt](https://github.com/GNOME/libxslt)
+* [libcurl](https://github.com/curl/curl)
+* [OpenSSL](https://github.com/KDAB/android_openssl)
 * [ICU](https://github.com/unicode-org/icu)
 
 

--- a/patches/gnustep-base-curl-cacert.patch
+++ b/patches/gnustep-base-curl-cacert.patch
@@ -1,0 +1,48 @@
+diff --git a/Source/GSEasyHandle.m b/Source/GSEasyHandle.m
+index 576a41205..7eb15d512 100644
+--- a/Source/GSEasyHandle.m
++++ b/Source/GSEasyHandle.m
+@@ -173,6 +173,24 @@ @implementation GSEasyHandle
+   struct curl_slist          *_headerList;
+ }
+ 
++#ifdef __ANDROID__
++static NSData *CABundleData() {
++  static NSData *result = nil;
++  static dispatch_once_t predicate;
++
++  dispatch_once(&predicate, ^{
++    NSString *caBundlePath = [[NSBundle mainBundle] pathForResource:@"cacert" ofType:@"pem"];
++    if (caBundlePath) {
++      result = [[NSData alloc] initWithContentsOfFile:caBundlePath];
++    } else {
++      NSLog(@"Warning: missing CA bundle path (cacert.pem) in app bundle");
++    }
++  });
++
++  return result;
++}
++#endif
++
+ - (instancetype) initWithDelegate: (id<GSEasyHandleDelegate>)delegate 
+ {
+   if (nil != (self = [super init])) 
+@@ -184,6 +202,18 @@ - (instancetype) initWithDelegate: (id<GSEasyHandleDelegate>)delegate
+       _errorBuffer = memset(eb, 0, sizeof(char) * (CURL_ERROR_SIZE + 1));
+       
+       [self setupCallbacks];
++
++#ifdef __ANDROID__
++      // set CA certificate store (must be stored in app bundle)
++      NSData *caBundleData = CABundleData();
++      if (caBundleData) {
++        struct curl_blob blob;
++        blob.data = (void *)caBundleData.bytes;
++        blob.len = caBundleData.length;
++        blob.flags = CURL_BLOB_COPY;
++        handleEasyCode(curl_easy_setopt(_rawHandle, CURLOPT_CAINFO_BLOB, &blob));
++      }
++#endif
+     }
+ 
+   return self;

--- a/phases/11-libobjc2.sh
+++ b/phases/11-libobjc2.sh
@@ -20,7 +20,6 @@ cd build-${ABI_NAME}
 
 ${CMAKE} .. \
   ${CMAKE_OPTIONS} \
-  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DGNUSTEP_CONFIG= `# prevent cmake from finding gnustep-config in install root` \
   -DOLDABI_COMPAT=false `# we're using gnustep-2.0 ABI, which may not be mixed with earlier versions'` \
 

--- a/phases/12-libdispatch.sh
+++ b/phases/12-libdispatch.sh
@@ -20,7 +20,6 @@ cd build-${ABI_NAME}
 
 ${CMAKE} .. \
   ${CMAKE_OPTIONS} \
-  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DBUILD_SHARED_LIBS=YES \
   -DINSTALL_PRIVATE_HEADERS=YES \
   `# use blocks runtime from libobjc2 with libdispatch-own-blocksruntime.patch` \

--- a/phases/15-icu.sh
+++ b/phases/15-icu.sh
@@ -6,7 +6,7 @@ set -e # make any subsequent failing command exit the script
 
 PROJECT=icu
 GITHUB_REPO=unicode-org/icu
-TAG=$(get_latest_github_release_tag $GITHUB_REPO)
+TAG=$(get_latest_github_release_tag $GITHUB_REPO release-)
 
 # don't clean project for subsequent builds so that the build for the current
 # machine is preserved, and because each ABI builds into separate directory

--- a/phases/18-openssl.sh
+++ b/phases/18-openssl.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e # make any subsequent failing command exit the script
+
+. `dirname $0`/../scripts/common.sh
+
+PROJECT=openssl
+GITHUB_REPO=KDAB/android_openssl
+
+# load environment and prepare project
+if ! prepare_project $PROJECT $GITHUB_REPO; then
+  exit 0
+fi
+
+case $ABI_NAME in
+  armeabi-v7a)
+    ABI_FOLDER=arm
+    ;;
+  arm64-v8a)
+    ABI_FOLDER=arm64
+    ;;
+  *)
+    ABI_FOLDER=$ABI_NAME
+esac
+
+echo -e "\n### Installing headers"
+
+cp -Rf no-asm/static/include/ ${INSTALL_PREFIX}/include
+
+echo -e "\n### Installing libraries"
+
+cp -f latest/$ABI_FOLDER/*.so ${INSTALL_PREFIX}/lib
+
+# create version-less symlinks for libcrypto/libssl.so to versioned libraries
+libraries=`ls latest/$ABI_FOLDER/*.so`
+cd ${INSTALL_PREFIX}/lib
+for lib in $libraries; do
+  libname=`basename $lib`
+  if [[ $libname =~ ([a-z]+)[0-9\_]+.so ]]; then
+    ln -sf $libname ${BASH_REMATCH[1]}.so
+  fi
+done
+
+echo -e "\n### Downloading CA bundle (must be installed into Android app bundle)"
+mkdir -p "$CACHE_ROOT"
+cd "$CACHE_ROOT"
+ETAG="cacert-etag.txt"
+[ -f $ETAG ] && ETAG_COMPARE="--etag-compare $ETAG"
+curl --show-error --fail-with-body --remote-name --etag-save $ETAG $ETAG_COMPARE https://curl.se/ca/cacert.pem
+mkdir -p ${INSTALL_PREFIX}/etc/ssl/
+cp -f cacert.pem ${INSTALL_PREFIX}/etc/ssl/

--- a/phases/19-libcurl.sh
+++ b/phases/19-libcurl.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e # make any subsequent failing command exit the script
+
+. `dirname $0`/../scripts/common.sh
+
+PROJECT=libcurl
+GITHUB_REPO=curl/curl
+TAG=$(get_latest_github_release_tag $GITHUB_REPO curl-)
+
+# load environment and prepare project
+if ! prepare_project $PROJECT $GITHUB_REPO $TAG; then
+  exit 0
+fi
+
+. "$ROOT_DIR"/scripts/toolchain.sh
+
+echo -e "\n### Running cmake"
+mkdir -p build-${ABI_NAME}
+cd build-${ABI_NAME}
+
+${CMAKE} .. \
+  ${CMAKE_OPTIONS} \
+  -DBUILD_SHARED_LIBS=YES \
+  -DBUILD_CURL_EXE=NO \
+  -DCURL_CA_BUNDLE=NONE `# disable CA bundle path, needs to be read at runtime from app bundle` \
+  -DCMAKE_FIND_ROOT_PATH=${INSTALL_PREFIX} `# make CMake look for OpenSSL in installation directory` \
+
+echo -e "\n### Building"
+make -j${MAKE_JOBS}
+
+echo -e "\n### Installing"
+make install

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -58,6 +58,7 @@ export LIBS="-lc++_shared"
 # common options for CMake-based projects
 # CMAKE_FIND_USE_CMAKE_PATH=false fixes finding incorrect libraries in $TOOLCHAIN/lib[64] instead of $TOOLCHAIN/sysroot/usr/lib/$ANDROID_TARGET, e.g. for libc++abi.a for libobjc2.
 CMAKE_OPTIONS=" \
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
   -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} \
   -DCMAKE_FIND_USE_CMAKE_PATH=false \


### PR DESCRIPTION
Enables support for NSURLSession in GNUstep Base.

Also adds [pre-built OpenSSL libraries](https://github.com/KDAB/android_openssl), which are required for libcurl, and fetches the [CA certificates](https://curl.se/docs/caextract.html) made available by the curl project to be included in the Android app bundle and used by NSURLSession to initialize curl.

See also https://github.com/gnustep/tools-windows-msvc/pull/15.