### PR TITLE
Various CI Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           if [ "$RUNNER_OS" = "macOS" ]; then
             brew install cmake autoconf automake libtool pkg-config
           elif [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get install curl cmake make libtool pkg-config texinfo python3-distutils
+            sudo apt-get install curl cmake make libtool pkg-config texinfo
 
             # install autoconf 2.71 from source (required by libffi, not available via apt-get on Ubuntu focal)
             wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.xz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           if [ "$RUNNER_OS" = "macOS" ]; then
             brew install cmake autoconf automake libtool pkg-config
           elif [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get install curl cmake make libtool pkg-config texinfo
+            sudo apt-get install curl cmake make libtool pkg-config texinfo libltdl-dev
 
             # install autoconf 2.71 from source (required by libffi, not available via apt-get on Ubuntu focal)
             wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.xz

--- a/phases/19-libcurl.sh
+++ b/phases/19-libcurl.sh
@@ -26,6 +26,7 @@ ${CMAKE} .. \
   -DCURL_CA_BUNDLE=NONE `# disable CA bundle path, needs to be read at runtime from app bundle` \
   -DUSE_LIBIDN2=NO `# Prevent accidental detection of an idn2 installation` \
   -DBUILD_LIBCURL_DOCS=NO \
+  -DCURL_USE_LIBPSL=NO \
   -DBUILD_MISC_DOCS=NO \
 
 echo -e "\n### Building"


### PR DESCRIPTION
- Remove `python3-distutils` and add `libltdl-dev` which is required for libffi's `./autogen.sh`.
- Disable [libpsl](https://everything.curl.dev/build/deps.html#:~:text=the%20RTMPDump%20project.-,libpsl,-https%3A//rockdaboot.github) which is apparently now enabled by default. We don't need it.