### PR TITLE
Android 16 KiB page alignment and OpenSSL upstream builds

### DIFF
--- a/patches/openssl-android-16k.patch
+++ b/patches/openssl-android-16k.patch
@@ -1,0 +1,31 @@
+From 66ed6db2ac83430e5bb768a44308df04ad685847 Mon Sep 17 00:00:00 2001
+From: vkryl <6242627+vkryl@users.noreply.github.com>
+Date: Fri, 15 Aug 2025 15:01:51 +0300
+Subject: [PATCH] Android: Enable 16 KB ELF alignment for `arm64-v8a` and
+ `x86_64` platforms
+
+CLA: trivial
+---
+ Configurations/15-android.conf | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Configurations/15-android.conf b/Configurations/15-android.conf
+index 1de6b7a91571d..26d9d6508f582 100644
+--- a/Configurations/15-android.conf
++++ b/Configurations/15-android.conf
+@@ -232,6 +232,7 @@ my %targets = (
+         bn_ops           => add("RC4_CHAR"),
+         asm_arch         => 'aarch64',
+         perlasm_scheme   => "linux64",
++        shared_ldflag    => add("-Wl,-z,max-page-size=16384"),
+     },
+ 
+     "android-mips" => {
+@@ -269,6 +270,7 @@ my %targets = (
+         bn_ops           => add("RC4_INT"),
+         asm_arch         => 'x86_64',
+         perlasm_scheme   => "elf",
++        shared_ldflag    => add("-Wl,-z,max-page-size=16384"),
+     },
+ 
+     "android-riscv64" => {

--- a/phases/18-openssl.sh
+++ b/phases/18-openssl.sh
@@ -5,30 +5,54 @@ set -e # make any subsequent failing command exit the script
 . `dirname $0`/../scripts/common.sh
 
 PROJECT=openssl
-GITHUB_REPO=KDAB/android_openssl
+GITHUB_REPO=openssl/openssl
+TAG=$(get_latest_github_release_tag $GITHUB_REPO)
 
 # load environment and prepare project
 if ! prepare_project $PROJECT $GITHUB_REPO; then
   exit 0
 fi
 
-echo -e "\n### Installing headers"
+BUILD_TARGET=
+case $ABI_NAME in
+  armeabi-v7a)
+    BUILD_TARGET=android-arm
+    ;;
+  arm64-v8a)
+    BUILD_TARGET=android-arm64
+    ;;
+  x86)
+    BUILD_TARGET=android-x86
+    ;;
+  x86_64)
+    BUILD_TARGET=android-x86_64
+    ;;
+  *)
+esac
 
-cp -Rf ssl_3/include/ ${INSTALL_PREFIX}/include
+SSL_BUILD_TYPE=release
+if [ "${BUILD_TYPE}" = "Debug" ]; then
+  SSL_BUILD_TYPE=debug
+fi
 
-echo -e "\n### Installing libraries"
 
-cp -f ssl_3/$ABI_NAME/*.so ${INSTALL_PREFIX}/lib
+echo -e "\n### Running configure"
+PATH=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/darwin-x86_64/bin:$PATH
+./Configure \
+  shared \
+  no-docs \
+  no-apps \
+  ${BUILD_TARGET} \
+  --prefix="${INSTALL_PREFIX}" \
+  --${SSL_BUILD_TYPE} \
+  -U__ANDROID_API__ \
+  -D__ANDROID_API__="${ANDROID_API_LEVEL}" \
 
-# create version-less symlinks for libcrypto/libssl.so to versioned libraries
-libraries=`ls ssl_3/$ABI_NAME/*.so`
-cd ${INSTALL_PREFIX}/lib
-for lib in $libraries; do
-  libname=`basename $lib`
-  if [[ $libname =~ ([a-z]+)[0-9\_]+.so ]]; then
-    ln -sf $libname ${BASH_REMATCH[1]}.so
-  fi
-done
+echo -e "\n### Building"
+make -j${MAKE_JOBS}
+
+echo -e "\n### Installing"
+make install
 
 echo -e "\n### Downloading CA bundle (must be installed into Android app bundle)"
 mkdir -p "$CACHE_ROOT"

--- a/phases/18-openssl.sh
+++ b/phases/18-openssl.sh
@@ -35,13 +35,21 @@ if [ "${BUILD_TYPE}" = "Debug" ]; then
   SSL_BUILD_TYPE=debug
 fi
 
+ANDROID_NDK_MAJOR=`basename $ANDROID_NDK_ROOT | cut -d. -f1`
+ASM=
+# Seems like there is a bug in the r26 ndk which prevents us from compiling some assembly
+if [ "$ANDROID_NDK_MAJOR" = "26" ]; then
+  ASM=no-asm
+fi
+
 
 echo -e "\n### Running configure"
-PATH=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/darwin-x86_64/bin:$PATH
+PATH=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/${HOST_TAG}/bin:$PATH
 ./Configure \
   shared \
   no-docs \
   no-apps \
+  ${ASM} \
   ${BUILD_TARGET} \
   --prefix="${INSTALL_PREFIX}" \
   --${SSL_BUILD_TYPE} \

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -40,12 +40,17 @@ export CFLAGS="$OPTFLAG -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIC"
 # --gc-sections is recommended to decrease binary size
 export LDFLAGS="-L${INSTALL_PREFIX}/lib -fuse-ld=lld -Wl,--build-id=sha1 -Wl,--no-rosegment -Wl,--gc-sections"
 
+ADDITIONAL_CMAKE_FLAGS=
 case $ABI_NAME in
   armeabi-v7a)
     # use Thumb instruction set for smaller code
     export CFLAGS="$CFLAGS -mthumb"
     # don't export symbols from libunwind
     export LDFLAGS="$LDFLAGS -Wl,--exclude-libs,libunwind.a"
+    ;;
+  arm64-v8a)
+    export LDFLAGS="$LDFLAGS -Wl,-z,max-page-size=16384"
+    ADDITIONAL_CMAKE_FLAGS="-Wl,-z,max-page-size=16384"
     ;;
   x86)
     # properly align stacks for global constructors when targeting API < 24
@@ -72,4 +77,5 @@ CMAKE_OPTIONS=" \
   -DANDROID_NDK=${ANDROID_NDK_ROOT} \
   -DANDROID_PLATFORM=android-${ANDROID_API_LEVEL} \
   -DANDROID_STL=c++_shared \
+  -DCMAKE_SHARED_LINKER_FLAGS=$ADDITIONAL_CMAKE_FLAGS \
 "

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -58,6 +58,10 @@ case $ABI_NAME in
       export CFLAGS="$CFLAGS -mstackrealign"
     fi
     ;;
+  x86_64)
+    export LDFLAGS="$LDFLAGS -Wl,-z,max-page-size=16384"
+    ADDITIONAL_CMAKE_FLAGS="-Wl,-z,max-page-size=16384"
+    ;;
 esac
 
 export CXXFLAGS=$CFLAGS


### PR DESCRIPTION
All arm64-v8a shared libraries are now aligned for 16 KiB pages. Additionally, I refactored the OpenSSL phase to instead build from upstream. By doing that, I removed support for OpenSSL V1.1.1. It was EOL'd years ago and Qt has since transitioned to OpenSSL 3.